### PR TITLE
Fix game window and environment misalignment

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -34,6 +34,7 @@ food_manager = FoodManager(world_bounds=(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT))
 # Create a colony at the center
 colony = Colony(position=(400, 300), max_population=50, spawn_rate=0.05)
 colony.set_pheromone_manager(pheromone_manager)
+colony.set_world_bounds((0, 0, SCREEN_WIDTH, SCREEN_HEIGHT))
 colony.receive_food(100.0)
 
 # Create queen controls UI


### PR DESCRIPTION
Allow ants to move across the entire game screen by correctly setting world boundaries.

Previously, ants were restricted to a hardcoded 800x600 area, despite the game screen being 1200x800. This PR updates the `Colony` class to manage and propagate the correct `1200x800` world bounds to all ants, ensuring they can utilize the full game environment.